### PR TITLE
Fix bulk heatmap vector generation failure

### DIFF
--- a/backend/app/bulk_engine/heatmap_bulk_core.py
+++ b/backend/app/bulk_engine/heatmap_bulk_core.py
@@ -246,8 +246,8 @@ def calculate_heatmap_path_vector(
     ) = _basis_conversion(
         contour_points,
         X,
-        image_fluo.shape[0] / 2,
-        image_fluo.shape[1] / 2,
+        image_fluo_gray.shape[0] / 2,
+        image_fluo_gray.shape[1] / 2,
         coords_inside_cell,
         as_array=True,
     )


### PR DESCRIPTION
## Summary
- Fixed bulk heatmap vector generation referencing an undefined `image_fluo` variable.
- Use the decoded grayscale image shape when passing image center coordinates to `_basis_conversion`.
- This prevents `/api/v1/get-heatmap-vectors` from incorrectly returning 404 when valid cells exist.

## Verification
- Confirmed `GET /api/v1/get-heatmap-vectors?dbname=test_database.db&label=1&channel=fluo1` returns `200`.
- Confirmed `GET /api/v1/get-heatmap-abs-plot?dbname=test_database.db&label=1&channel=fluo1` returns `200 image/png`.
- Directly verified `calculate_heatmap_path_vector` returns vectors for a sample cell.

## Notes
- `pytest` was not run because `pytest` is not installed in the local venv.
- Exclude `backend/app/databases/test_database.db` from the PR; it was modified during local API verification.