### PR TITLE
Add MIT license metadata and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,11 @@ Module-specific READMEs:
    *why*, and *how it was tested*. Link any related issue (`Closes #123`).
 6. **Iterate on review.** Push additional commits; we squash-merge on accept.
 
+## Contribution licensing
+
+By submitting a contribution, you agree that your contribution is licensed
+under the same MIT License that covers PhenoPixel.
+
 ## Coding guidelines
 
 ### Python (backend)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yunosuke Ikeda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -439,3 +439,8 @@ Frontend:
 - Bulk Engine API: [backend/app/bulk_engine/README.md](backend/app/bulk_engine/README.md)
 - Cell Extraction API: [backend/app/cellextraction/README.md](backend/app/cellextraction/README.md)
 - Frontend: [frontend/README.md](frontend/README.md)
+
+## License
+
+PhenoPixel is released under the MIT License. See [LICENSE](LICENSE) for details.
+Third-party dependencies remain under their respective licenses.

--- a/Readme_ja.md
+++ b/Readme_ja.md
@@ -404,3 +404,8 @@ Traefik は `80/443` を使用する。`SERVER_HOST` に設定したホスト名
 - バルクエンジン API: [backend/app/bulk_engine/README.md](backend/app/bulk_engine/README.md)
 - 細胞抽出 API: [backend/app/cellextraction/README.md](backend/app/cellextraction/README.md)
 - フロントエンド: [frontend/README.md](frontend/README.md)
+
+## ライセンス
+
+PhenoPixel は MIT License の下で公開されています。詳細は [LICENSE](LICENSE) を参照してください。
+サードパーティ依存関係は、それぞれのライセンスに従います。

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "frontend",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "@chakra-ui/react": "^3.30.0",
         "@emotion/react": "^11.14.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "0.0.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "concurrently -k -s first -n APP,DOCS \"vite\" \"npm run docs:dev\"",


### PR DESCRIPTION
## Summary
- Add the MIT License to the repository root
- Document the project license in the English and Japanese READMEs
- Add MIT license metadata to the frontend package files
- Clarify that contributions are submitted under the same MIT License

## Verification
- Confirmed `package.json` and `package-lock.json` parse successfully
- Confirmed `npm pkg get license` returns `MIT`
- Ran `git diff --check`