### PR TITLE
Fix : graphengine 

### DIFF
--- a/backend/app/graphengine/router.py
+++ b/backend/app/graphengine/router.py
@@ -18,10 +18,62 @@ class GraphEngineResultResponse(BaseModel):
     nagg_rate: float | None
 
 
+async def _render_graph_engine_image(
+    render_fn: Callable[[str | None, bytes], bytes],
+    mode: str | None,
+    file: UploadFile,
+) -> StreamingResponse:
+    try:
+        content: bytes = await file.read()
+        if not content:
+            raise ValueError("Uploaded file is empty")
+        loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
+        image_bytes: bytes = await loop.run_in_executor(None, render_fn, mode, content)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        await file.close()
+    return StreamingResponse(io.BytesIO(image_bytes), media_type="image/png")
+
+
+@router_graphengine.post("/graph_engine/heatmap_abs")
+async def graph_engine_heatmap_abs(
+    file: Annotated[UploadFile, File()],
+    mode: Annotated[str | None, Form()] = None,
+) -> StreamingResponse:
+    return await _render_graph_engine_image(GraphEngineCrud.create_heatmap_abs_plot, mode, file)
+
+
+@router_graphengine.post("/graph_engine/heatmap_rel")
+async def graph_engine_heatmap_rel(
+    file: Annotated[UploadFile, File()],
+    mode: Annotated[str | None, Form()] = None,
+) -> StreamingResponse:
+    return await _render_graph_engine_image(GraphEngineCrud.create_heatmap_rel_plot, mode, file)
+
+
+@router_graphengine.post("/graph_engine/distribution")
+async def graph_engine_distribution(
+    file: Annotated[UploadFile, File()],
+    mode: Annotated[str | None, Form()] = None,
+) -> StreamingResponse:
+    return await _render_graph_engine_image(GraphEngineCrud.create_distribution_plot, mode, file)
+
+
+@router_graphengine.post("/graph_engine/distribution_box")
+async def graph_engine_distribution_box(
+    file: Annotated[UploadFile, File()],
+    mode: Annotated[str | None, Form()] = None,
+) -> StreamingResponse:
+    return await _render_graph_engine_image(GraphEngineCrud.create_distribution_box_plot, mode, file)
+
+
 @router_graphengine.post("/graph_engine/{mode}", response_model=list[GraphEngineResultResponse])
 async def analyze_graph_engine(
     mode: str,
-    files: Annotated[list[UploadFile], File()] = ...,
+    files: Annotated[list[UploadFile], File()],
     ctrl_file: Annotated[UploadFile | None, File()] = None,
 ) -> list[GraphEngineResultResponse]:
     if not files:
@@ -57,55 +109,3 @@ async def analyze_graph_engine(
         )
         for result in results
     ]
-
-
-async def _render_graph_engine_image(
-    render_fn: Callable[[str | None, bytes], bytes],
-    mode: str | None,
-    file: UploadFile,
-) -> StreamingResponse:
-    try:
-        content: bytes = await file.read()
-        if not content:
-            raise ValueError("Uploaded file is empty")
-        loop: asyncio.AbstractEventLoop = asyncio.get_running_loop()
-        image_bytes: bytes = await loop.run_in_executor(None, render_fn, mode, content)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
-    finally:
-        await file.close()
-    return StreamingResponse(io.BytesIO(image_bytes), media_type="image/png")
-
-
-@router_graphengine.post("/graph_engine/heatmap_abs")
-async def graph_engine_heatmap_abs(
-    file: Annotated[UploadFile, File()] = ...,
-    mode: Annotated[str | None, Form()] = None,
-) -> StreamingResponse:
-    return await _render_graph_engine_image(GraphEngineCrud.create_heatmap_abs_plot, mode, file)
-
-
-@router_graphengine.post("/graph_engine/heatmap_rel")
-async def graph_engine_heatmap_rel(
-    file: Annotated[UploadFile, File()] = ...,
-    mode: Annotated[str | None, Form()] = None,
-) -> StreamingResponse:
-    return await _render_graph_engine_image(GraphEngineCrud.create_heatmap_rel_plot, mode, file)
-
-
-@router_graphengine.post("/graph_engine/distribution")
-async def graph_engine_distribution(
-    file: Annotated[UploadFile, File()] = ...,
-    mode: Annotated[str | None, Form()] = None,
-) -> StreamingResponse:
-    return await _render_graph_engine_image(GraphEngineCrud.create_distribution_plot, mode, file)
-
-
-@router_graphengine.post("/graph_engine/distribution_box")
-async def graph_engine_distribution_box(
-    file: Annotated[UploadFile, File()] = ...,
-    mode: Annotated[str | None, Form()] = None,
-) -> StreamingResponse:
-    return await _render_graph_engine_image(GraphEngineCrud.create_distribution_box_plot, mode, file)

--- a/backend/tests/test_graphengine_router.py
+++ b/backend/tests/test_graphengine_router.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import unittest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.graphengine.router import router_graphengine
+
+
+def _sample_heatmap_csv() -> bytes:
+    axis = ",".join(str(index) for index in range(35))
+    peaks = ",".join(str((index % 7) + 1) for index in range(35))
+    return f"{axis}\n{peaks}\n".encode("utf-8")
+
+
+class GraphEngineRouterTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        app = FastAPI()
+        app.include_router(router_graphengine, prefix="/api/v1")
+        cls.client = TestClient(app, raise_server_exceptions=False)
+
+    def test_analyze_route_accepts_uploaded_csv_files(self):
+        response = self.client.post(
+            "/api/v1/graph_engine/HU_aggregation_ratio",
+            files=[("files", ("sample.csv", _sample_heatmap_csv(), "text/csv"))],
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            [{"filename": "sample.csv", "mean_length": 2.21, "nagg_rate": None}],
+        )
+
+    def test_image_routes_are_not_shadowed_by_mode_route(self):
+        for endpoint in (
+            "heatmap_abs",
+            "heatmap_rel",
+            "distribution",
+            "distribution_box",
+        ):
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(
+                    f"/api/v1/graph_engine/{endpoint}",
+                    files={"file": ("sample.csv", _sample_heatmap_csv(), "text/csv")},
+                    data={"mode": "HU_aggregation_ratio"},
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.headers["content-type"], "image/png")
+                self.assertGreater(len(response.content), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
https://github.com/ikeda042/PhenoPixel/issues/14

Fix Graph Engine image endpoints being shadowed by the dynamic mode route.

The static image routes such as `/graph_engine/heatmap_abs` were registered after `/graph_engine/{mode}`, so FastAPI matched them as `mode` values and routed requests to the analysis endpoint. This caused image requests from the frontend to fail because they upload `file`, while the analysis endpoint expects `files`.

Changes:
- Register Graph Engine image routes before `/graph_engine/{mode}`.
- Clean up required upload parameter declarations.
- Add regression tests for the analysis endpoint and all image endpoints.

Verified with the backend test suite.