### PR TITLE
Enhance large image tile extraction with metadata detection 

### DIFF
--- a/backend/app/cellextraction/README.md
+++ b/backend/app/cellextraction/README.md
@@ -16,6 +16,9 @@ http://<host>:<port>/api/v1
 - Use the filename only (no paths); only `.nd2` is accepted.
 - Dots in filenames are replaced with `p` during processing; use the returned
   `nd2_stem` for output folder names.
+- NIS-Elements Large Image ND2 files are auto-detected from metadata. When the
+  recorded field grid and camera frame size match the final image dimensions,
+  the combined image is split into per-field frames before contour extraction.
 
 ## Concurrency
 

--- a/backend/app/cellextraction/crud.py
+++ b/backend/app/cellextraction/crud.py
@@ -284,6 +284,15 @@ class FrameSplitRange:
     db_path: str
 
 
+@dataclass(frozen=True)
+class LargeImageTileLayout:
+    x_fields: int
+    y_fields: int
+    tile_width: int
+    tile_height: int
+    source: str
+
+
 class Cell(Base):
     __tablename__ = "cells"
     __table_args__ = (
@@ -341,6 +350,221 @@ def create_database(dbname: str) -> Engine:
 
 
 class SyncChores:
+    @staticmethod
+    def _metadata_key(value: object) -> str:
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="ignore")
+        return str(value)
+
+    @staticmethod
+    def _metadata_lookup(mapping: object, key: str) -> object | None:
+        if not isinstance(mapping, dict):
+            return None
+        candidates: tuple[object, ...] = (key, key.encode("utf-8"))
+        for candidate in candidates:
+            if candidate in mapping:
+                return mapping[candidate]
+        for existing_key, value in mapping.items():
+            if SyncChores._metadata_key(existing_key) == key:
+                return value
+        return None
+
+    @staticmethod
+    def _metadata_scalar(value: object) -> object:
+        while isinstance(value, dict):
+            unwrapped = SyncChores._metadata_lookup(value, "@value")
+            if unwrapped is None:
+                break
+            value = unwrapped
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="ignore")
+        if isinstance(value, np.generic):
+            return value.item()
+        return value
+
+    @staticmethod
+    def _metadata_int(value: object) -> int | None:
+        value = SyncChores._metadata_scalar(value)
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _iter_named_metadata_entries(
+        value: object, names: set[str]
+    ) -> Generator[tuple[str, dict], None, None]:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                key_name = SyncChores._metadata_key(key)
+                if key_name in names and isinstance(child, dict):
+                    yield key_name, child
+                yield from SyncChores._iter_named_metadata_entries(child, names)
+        elif isinstance(value, (list, tuple)):
+            for child in value:
+                yield from SyncChores._iter_named_metadata_entries(child, names)
+
+    @staticmethod
+    def _large_image_field_candidates(raw_metadata: object) -> list[tuple[str, int, int, int]]:
+        image_metadata = getattr(raw_metadata, "image_metadata", None)
+        candidates: list[tuple[str, int, int, int]] = []
+        for source, entry in SyncChores._iter_named_metadata_entries(
+            image_metadata, {"pLargeImage", "pLargeImageEx"}
+        ):
+            x_fields = SyncChores._metadata_int(
+                SyncChores._metadata_lookup(entry, "iXFields")
+            )
+            y_fields = SyncChores._metadata_int(
+                SyncChores._metadata_lookup(entry, "iYFields")
+            )
+            if not x_fields or not y_fields:
+                continue
+            if x_fields < 1 or y_fields < 1 or x_fields * y_fields <= 1:
+                continue
+            valid = SyncChores._metadata_int(SyncChores._metadata_lookup(entry, "bValid"))
+            candidates.append((source, x_fields, y_fields, valid or 0))
+        return candidates
+
+    @staticmethod
+    def _camera_tile_shapes(raw_metadata: object) -> set[tuple[int, int]]:
+        shapes: set[tuple[int, int]] = set()
+        for attr in ("image_metadata_sequence", "grabber_settings"):
+            metadata = getattr(raw_metadata, attr, None)
+            for _source, entry in SyncChores._iter_named_metadata_entries(
+                metadata, {"sizeObjFullChip", "sizeSensorPixels"}
+            ):
+                width = SyncChores._metadata_int(SyncChores._metadata_lookup(entry, "cx"))
+                height = SyncChores._metadata_int(SyncChores._metadata_lookup(entry, "cy"))
+                if width and height and width > 1 and height > 1:
+                    shapes.add((width, height))
+        return shapes
+
+    @staticmethod
+    def _detect_large_image_tile_layout(images) -> LargeImageTileLayout | None:
+        raw_metadata = getattr(getattr(images, "parser", None), "_raw_metadata", None)
+        if raw_metadata is None:
+            return None
+        sizes = getattr(images, "sizes", {}) or {}
+        width = SyncChores._metadata_int(sizes.get("x"))
+        height = SyncChores._metadata_int(sizes.get("y"))
+        if not width or not height:
+            return None
+
+        candidates = SyncChores._large_image_field_candidates(raw_metadata)
+        if not candidates:
+            return None
+
+        camera_shapes = SyncChores._camera_tile_shapes(raw_metadata)
+        scored: list[tuple[int, LargeImageTileLayout]] = []
+        has_camera_shape_match = False
+        divisible_candidates: list[tuple[str, int, int, int, int, int]] = []
+        for source, x_fields, y_fields, valid in candidates:
+            if width % x_fields != 0 or height % y_fields != 0:
+                continue
+            tile_width = width // x_fields
+            tile_height = height // y_fields
+            if (tile_width, tile_height) in camera_shapes:
+                has_camera_shape_match = True
+            divisible_candidates.append(
+                (source, x_fields, y_fields, valid, tile_width, tile_height)
+            )
+
+        if camera_shapes and not has_camera_shape_match:
+            return None
+
+        for source, x_fields, y_fields, valid, tile_width, tile_height in divisible_candidates:
+            if camera_shapes and (tile_width, tile_height) not in camera_shapes:
+                continue
+            score = x_fields * y_fields
+            if (tile_width, tile_height) in camera_shapes:
+                score += 1000
+            if source == "pLargeImage":
+                score += 100
+            if valid:
+                score += 10
+            scored.append(
+                (
+                    score,
+                    LargeImageTileLayout(
+                        x_fields=x_fields,
+                        y_fields=y_fields,
+                        tile_width=tile_width,
+                        tile_height=tile_height,
+                        source=source,
+                    ),
+                )
+            )
+
+        if not scored:
+            return None
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return scored[0][1]
+
+    @staticmethod
+    def _layer_array_from_frame(
+        frame: object, source_idx: int, num_channels: int
+    ) -> np.ndarray | None:
+        if num_channels > 1:
+            if source_idx >= num_channels:
+                return None
+            return np.squeeze(np.asarray(frame[source_idx]))
+        if source_idx != 0:
+            return None
+        return np.squeeze(np.asarray(frame))
+
+    @staticmethod
+    def _write_large_image_tiles(
+        images,
+        specs: list[tuple[int, str | None]],
+        temp_dir: str,
+        layout: LargeImageTileLayout,
+    ) -> int:
+        num_channels = int(images.sizes.get("c", 1) or 1)
+        frame_index = 0
+        expected_height = layout.tile_height * layout.y_fields
+        expected_width = layout.tile_width * layout.x_fields
+
+        for image_index in range(len(images)):
+            try:
+                frame = images[image_index]
+            except KeyError as exc:
+                print(f"KeyError while reading frame {image_index}: {exc}. Stopping extraction.")
+                break
+            layer_arrays: dict[int, np.ndarray] = {}
+            for source_idx, layer in specs:
+                if layer is None:
+                    continue
+                array = SyncChores._layer_array_from_frame(frame, source_idx, num_channels)
+                if array is None:
+                    continue
+                if array.ndim < 2:
+                    raise ValueError("Large Image frame must have at least two dimensions")
+                if array.shape[0] != expected_height or array.shape[1] != expected_width:
+                    raise ValueError(
+                        "Large Image tile layout does not match frame dimensions "
+                        f"({array.shape[1]}x{array.shape[0]} vs "
+                        f"{expected_width}x{expected_height})"
+                    )
+                layer_arrays[source_idx] = array
+
+            for tile_y in range(layout.y_fields):
+                y0 = tile_y * layout.tile_height
+                y1 = y0 + layout.tile_height
+                for tile_x in range(layout.x_fields):
+                    x0 = tile_x * layout.tile_width
+                    x1 = x0 + layout.tile_width
+                    for source_idx, layer in specs:
+                        if layer is None:
+                            continue
+                        array = layer_arrays.get(source_idx)
+                        if array is None:
+                            continue
+                        tile = array[y0:y1, x0:x1, ...]
+                        tile = SyncChores.prepare_extracted_layer(tile, layer)
+                        Image.fromarray(tile).save(f"{temp_dir}/{layer}/{frame_index}.tif")
+                    frame_index += 1
+        return frame_index
+
     @staticmethod
     def to_grayscale_preserve_depth(image) -> np.ndarray:
         array = np.squeeze(np.asarray(image))
@@ -467,11 +691,28 @@ class SyncChores:
             print(f"Sizes: {images.sizes}")
 
             images.bundle_axes = "cyx" if "c" in images.axes else "yx"
-            images.iter_axes = "v"
+            iter_axes = (
+                "v"
+                if "v" in images.axes
+                else "".join(axis for axis in images.axes if axis not in images.bundle_axes)
+            )
+            images.iter_axes = iter_axes
+            tile_layout = SyncChores._detect_large_image_tile_layout(images)
 
             num_channels = images.sizes.get("c", 1)
             print(f"Total images: {len(images)}")
             print(f"Channels: {num_channels}")
+            if tile_layout is not None:
+                print(
+                    "Detected Large Image tile layout: "
+                    f"{tile_layout.x_fields}x{tile_layout.y_fields} "
+                    f"({tile_layout.tile_width}x{tile_layout.tile_height}px, "
+                    f"{tile_layout.source})"
+                )
+                frames_processed = SyncChores._write_large_image_tiles(
+                    images, specs, temp_dir, tile_layout
+                )
+                return frames_processed * len(specs)
             print("##############################################")
 
             frames_processed = 0
@@ -484,15 +725,11 @@ class SyncChores:
                 for source_idx, layer in specs:
                     if layer is None:
                         continue
-                    if num_channels > 1:
-                        if source_idx >= num_channels:
-                            continue
-                        array = np.asarray(frame[source_idx])
-                    else:
-                        if source_idx != 0:
-                            continue
-                        array = np.asarray(frame)
-                    array = np.squeeze(array)
+                    array = SyncChores._layer_array_from_frame(
+                        frame, source_idx, int(num_channels or 1)
+                    )
+                    if array is None:
+                        continue
                     array = SyncChores.prepare_extracted_layer(array, layer)
                     Image.fromarray(array).save(f"{temp_dir}/{layer}/{n}.tif")
                 frames_processed += 1

--- a/backend/tests/test_large_image_tile_split.py
+++ b/backend/tests/test_large_image_tile_split.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from app.cellextraction.crud import LargeImageTileLayout, SyncChores
+
+
+class _RawMetadata:
+    def __init__(self) -> None:
+        self.image_metadata = {
+            b"SLxExperiment": {
+                b"ppNextLevelEx": {
+                    b"": {
+                        b"pLargeImage": {
+                            b"bValid": 1,
+                            b"iXFields": 4,
+                            b"iYFields": 4,
+                        },
+                        b"pLargeImageEx": {
+                            b"bValid": 1,
+                            b"iXFields": 2,
+                            b"iYFields": 2,
+                        },
+                    }
+                }
+            }
+        }
+        self.image_metadata_sequence = {
+            b"SLxPictureMetadata": {
+                b"sPicturePlanes": {
+                    b"sPlaneNew": {
+                        b"a0": {
+                            b"sizeObjFullChip": {
+                                b"cx": 2048,
+                                b"cy": 2044,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        self.grabber_settings = {}
+
+
+class _Parser:
+    def __init__(self, raw_metadata: _RawMetadata) -> None:
+        self._raw_metadata = raw_metadata
+
+
+class _Images:
+    def __init__(
+        self,
+        frames: list[np.ndarray],
+        raw_metadata: _RawMetadata,
+        sizes: dict[str, int] | None = None,
+    ) -> None:
+        self._frames = frames
+        self.sizes = sizes or {"x": 8192, "y": 8176}
+        self.parser = _Parser(raw_metadata)
+
+    def __len__(self) -> int:
+        return len(self._frames)
+
+    def __getitem__(self, index: int) -> np.ndarray:
+        return self._frames[index]
+
+
+class LargeImageTileSplitTest(unittest.TestCase):
+    def test_detect_large_image_prefers_camera_tile_consistent_candidate(self):
+        images = _Images([np.zeros((8176, 8192), dtype=np.uint16)], _RawMetadata())
+
+        layout = SyncChores._detect_large_image_tile_layout(images)
+
+        self.assertIsNotNone(layout)
+        assert layout is not None
+        self.assertEqual(layout.x_fields, 4)
+        self.assertEqual(layout.y_fields, 4)
+        self.assertEqual(layout.tile_width, 2048)
+        self.assertEqual(layout.tile_height, 2044)
+        self.assertEqual(layout.source, "pLargeImage")
+
+    def test_detect_large_image_rejects_camera_tile_mismatch(self):
+        images = _Images(
+            [np.zeros((8176, 8200), dtype=np.uint16)],
+            _RawMetadata(),
+            sizes={"x": 8200, "y": 8176},
+        )
+
+        self.assertIsNone(SyncChores._detect_large_image_tile_layout(images))
+
+    def test_write_large_image_tiles_saves_each_tile_as_a_frame(self):
+        raw = _RawMetadata()
+        frame = np.zeros((4, 4), dtype=np.uint16)
+        frame[0:2, 0:2] = 10
+        frame[0:2, 2:4] = 20
+        frame[2:4, 0:2] = 30
+        frame[2:4, 2:4] = 40
+        images = _Images([frame], raw, sizes={"x": 4, "y": 4})
+        layout = SyncChores._detect_large_image_tile_layout(images)
+        self.assertIsNone(layout)
+
+        # Use a hand-built layout here so this test focuses on write ordering.
+        layout = LargeImageTileLayout(
+            x_fields=2,
+            y_fields=2,
+            tile_width=2,
+            tile_height=2,
+            source="test",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fluo_dir = Path(tmpdir) / "Fluo1"
+            fluo_dir.mkdir()
+
+            frames = SyncChores._write_large_image_tiles(
+                images,
+                [(0, "Fluo1")],
+                tmpdir,
+                layout,
+            )
+
+            self.assertEqual(frames, 4)
+            means = []
+            for index in range(4):
+                tile = cv2.imread(str(fluo_dir / f"{index}.tif"), cv2.IMREAD_UNCHANGED)
+                self.assertIsNotNone(tile)
+                means.append(int(np.mean(tile)))
+            self.assertEqual(means, [10, 20, 30, 40])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds automatic support for NIS-Elements Large Image ND2 files in Cell Extraction.

Some ND2 files store multiple microscope fields as a single stitched/combined image instead of exposing them as separate `v` frames. This change detects that structure from ND2 metadata, validates the detected grid against the final image size and camera frame size, then splits the combined image into per-field frames before running the existing cell extraction pipeline.

## Changes

- Added Large Image tile layout detection from `pLargeImage` / `pLargeImageEx` metadata.
- Validates candidate layouts against ND2 image dimensions and camera tile dimensions.
- Splits detected Large Image frames into per-field TIFFs using the existing layer output folders.
- Preserves the existing `v`-axis behavior for standard multi-field ND2 files.
- Falls back to the existing extraction path when Large Image metadata is missing or inconsistent.
- Added unit tests for layout detection, mismatch rejection, and tile write ordering.
- Documented automatic Large Image handling in the Cell Extraction README.

## Verification

- Confirmed the sample ND2 is auto-detected as `4x4 (2048x2044px, pLargeImage)`.
- Confirmed it produces 16 per-field PH TIFFs.
- Ran:

```sh
PYTHONPATH=backend ./venv/bin/python -m unittest backend.tests.test_large_image_tile_split backend.tests.test_raw_fluorescence_preservation backend.tests.test_objective_scale_support
PYTHONPATH=backend ./venv/bin/python -m compileall -q backend/app/cellextraction backend/tests/test_large_image_tile_split.py